### PR TITLE
include scala-java-time and other platform-appropriate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ Parse Scala string literals into `java.time` instances at compile time.
 > duration"PT20.345S"
 val res0: java.time.Duration = PT20.345S
 ```
+
+See the [test suite for comprehensive examples](https://github.com/bpholt/java-time-literals/blob/main/core/shared/src/test/scala/dev/holt/javatime/JavaTimeSuite.scala)
+of all supported literal types.
+
+## Scala.js and Scala Native
+
+Since Scala.js and Scala Native don't have a built-in timezone database, if you need to use
+timezones other than UTC on those platforms, make sure to include
+
+```scala
+"io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.5.0"
+```
+
+in your project dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ lazy val V = new {
   val SCALA_3 = "3.2.2"
   val Scalas = Seq(SCALA_2_13, SCALA_2_12, SCALA_3)
   val literally = "1.1.0"
-  val munit = "0.7.29"
+  val scalaJavaTime = "2.5.0"
+  val munit = "1.0.0-M7"
 }
 
 ThisBuild / scalaVersion := V.Scalas.head
@@ -49,9 +50,11 @@ lazy val `java-time-literals` = crossProject(JSPlatform, JVMPlatform, NativePlat
 
       scalaReflect ++
         Seq(
-          "org.typelevel" %% "literally" % V.literally,
-          "org.scalameta" %% "munit" % V.munit % Test,
-          "org.scalameta" %% "munit-scalacheck" % V.munit % Test,
+          "org.typelevel" %%% "literally" % V.literally,
+          "io.github.cquiroz" %%% "scala-java-time" % V.scalaJavaTime,
+          "org.scalameta" %%% "munit" % V.munit % Test,
+          "org.scalameta" %%% "munit-scalacheck" % V.munit % Test,
+          "io.github.cquiroz" %%% "scala-java-time-tzdb" % V.scalaJavaTime % Test,
         )
     },
   )


### PR DESCRIPTION
Includes `scala-java-time-tzdb` in the `Test` scope only so we can test across multiple timezones without forcing that dependency on all users.